### PR TITLE
Changelog 3.0.0

### DIFF
--- a/.openapi-generator-ignore
+++ b/.openapi-generator-ignore
@@ -26,3 +26,4 @@ README.md
 .rubocop.yml
 .gitignore
 .travis.yml
+CHANGELOG.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [3.0.0] - 2020-05-29
+### Changed
+
+Add application-authentication #18
+Add last_available_at, last_checked_at to Source/Endpoint/Authentication/Application #19
+
+## [1.0.0] - 2020-02-10
+### Initial release to rubygems.org
+
+[Unreleased]: https://github.com/RedHatInsights/sources-api-client-ruby/compare/v3.0.0...HEAD
+[3.0.0]: https://github.com/RedHatInsights/sources-api-client-ruby/compare/v1.0.0...3.0.0
+[1.0.0]: https://github.com/RedHatInsights/sources-api-client-ruby/releases/v1.0.0

--- a/lib/sources-api-client/version.rb
+++ b/lib/sources-api-client/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.2.1
 =end
 
 module SourcesApiClient
-  VERSION = '1.0.0'
+  VERSION = '3.0.0'
 end


### PR DESCRIPTION
**Gem version: 3.0.0**
* [x] released to RubyGems

Note: It reflects the Sources API is version 3.0, can we skip major version 2.0 of this gem?

---

- [x] **depends on** #18 
- [x] **depends on** #19