### PR TITLE
Availability_status_error is nullable

### DIFF
--- a/lib/sources-api-client/models/application.rb
+++ b/lib/sources-api-client/models/application.rb
@@ -68,6 +68,7 @@ module SourcesApiClient
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
+        :'availability_status_error',
       ])
     end
 

--- a/lib/sources-api-client/models/authentication.rb
+++ b/lib/sources-api-client/models/authentication.rb
@@ -87,6 +87,7 @@ module SourcesApiClient
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
+        :'availability_status_error',
       ])
     end
 

--- a/lib/sources-api-client/models/endpoint.rb
+++ b/lib/sources-api-client/models/endpoint.rb
@@ -106,6 +106,7 @@ module SourcesApiClient
     # List of attributes with nullable: true
     def self.openapi_nullable
       Set.new([
+        :'availability_status_error',
       ])
     end
 

--- a/lib/sources-api-client/version.rb
+++ b/lib/sources-api-client/version.rb
@@ -11,5 +11,5 @@ OpenAPI Generator version: 4.2.1
 =end
 
 module SourcesApiClient
-  VERSION = '3.0.0'
+  VERSION = '3.0.1'
 end


### PR DESCRIPTION
Settings availability_status_error as nullable (it means can be set to nil)

* [ ] **depends on** https://github.com/RedHatInsights/sources-api/pull/231

---

[TPINVTRY-948](https://projects.engineering.redhat.com/browse/TPINVTRY-948)